### PR TITLE
update nginx-too-many-requests-retryafter.patch for nginx-1.16.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.5
 
 MAINTAINER Taichiro Yoshida "taichiro.yoshida@nulab-inc.com"
-LABEL version=1.14.0
-ENV NGINX_VERSION 1.14.0
+LABEL version=1.16.1
+ENV NGINX_VERSION 1.16.1
 STOPSIGNAL SIGQUIT
 EXPOSE 80
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Installation
 
 ```
-tar zxfv nginx-1.14.0.tar.gz
-cd nginx-1.14.0
+tar zxfv nginx-1.61.1.tar.gz
+cd nginx-1.61.1
 patch -p1 < ../nginx-too-many-requests-retryafter.patch
 ./configure ...
 ```
@@ -36,10 +36,10 @@ $ ab -i -v 2 -n 2 -c 2 http://127.0.0.1/
 ...
 LOG: header received:
 HTTP/1.1 429 Too Many Requests
-Server: nginx/1.14.0
-Date: Mon, 28 May 2018 07:49:10 GMT
+Server: nginx/1.16.1
+Date: Tue, 08 Oct 2019 03:49:19 GMT
 Content-Type: text/html
-Content-Length: 185
+Content-Length: 169
 Connection: close
 Retry-After: 1
 ...
@@ -51,6 +51,7 @@ The following versions of Nginx should work with this module:
 
 Module version | Nginx version
 --- | ---
+1.2.0 | 1.16.x or higher
 1.1.0 | 1.14.x or higher
 1.0.0 | 1.13.x or earlier
 

--- a/nginx-too-many-requests-retryafter.patch
+++ b/nginx-too-many-requests-retryafter.patch
@@ -1,6 +1,6 @@
-diff -Bbu -ur nginx-1.12.0/src/http/modules/ngx_http_limit_req_module.c nginx-1.12.0-retry-after-pached/src/http/modules/ngx_http_limit_req_module.c
---- nginx-1.12.0/src/http/modules/ngx_http_limit_req_module.c	2017-04-12 10:46:02.000000000 -0400
-+++ nginx-1.12.0-retry-after-pached/src/http/modules/ngx_http_limit_req_module.c	2017-04-25 12:09:35.000000000 -0400
+diff -Bbu -ur nginx-1.16.1/src/http/modules/ngx_http_limit_req_module.c nginx-1.16.0-retry-after-pached/src/http/modules/ngx_http_limit_req_module.c
+--- nginx-1.16.1/src/http/modules/ngx_http_limit_req_module.c	2019-08-13 21:51:43.000000000 +0900
++++ nginx-1.16.0-retry-after-pached/src/http/modules/ngx_http_limit_req_module.c	2019-10-08 12:16:08.422640718 +0900
 @@ -164,6 +164,9 @@
      ngx_http_limit_req_ctx_t    *ctx;
      ngx_http_limit_req_conf_t   *lrcf;
@@ -44,7 +44,7 @@ diff -Bbu -ur nginx-1.12.0/src/http/modules/ngx_http_limit_req_module.c nginx-1.
          }
  
          while (n--) {
-@@ -712,7 +727,7 @@
+@@ -733,7 +748,7 @@
                                  NGX_LOG_INFO : conf->limit_log_level + 1;
  
      ngx_conf_merge_uint_value(conf->status_code, prev->status_code,


### PR DESCRIPTION
it's only different of the line number with previous patch.